### PR TITLE
Update requirements.txt

### DIFF
--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -33,7 +33,6 @@ MarkupSafe==2.1.1
 matplotlib==3.6.2
 netifaces==0.11.0
 numpy==1.23.4
-opencv-python==4.6.0.66
 opencv-python-headless==4.6.0.66
 packaging==21.3
 pandas==1.5.1


### PR DESCRIPTION
remove `opencv-python` in favor of `opencv-python-headless` for better compatibility with Streamlit

# Description

* remove `opencv-python==4.6.0.66` from from `requirements.txt`
* keep `opencv-python-headless==4.6.0.66` in `requirements.txt`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

* tested in the deployed app, locally, on my Macbook and with a Linux computer (Ubuntu 20)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
